### PR TITLE
Fix missing /var/run/rtorrent directory

### DIFF
--- a/overlay/etc/init.d/rtorrent
+++ b/overlay/etc/init.d/rtorrent
@@ -20,9 +20,19 @@ delete_socket() {
     fi
 }
 
+create_socket_dir() {
+    SOCKET_DIR=$(dirname "$SOCKET")
+    if [ ! -d "$SOCKET_DIR" ]; then
+        mkdir -p "$SOCKET_DIR"
+        chmod 750 "$SOCKET_DIR"
+        chown $USER:www-data "$SOCKET_DIR"
+    fi
+}
+
 case "$1" in
     start)
         echo "Starting rtorrent."
+        create_socket_dir
         delete_socket
         su - rtorrent -s /bin/bash -c "$TMUX new-session -c $WD -s rtorrent -n rtorrent -d rtorrent"
         if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Failed to starting `rtorrent` service because missing `/var/run/rtorrent` directory to store socket file, with error messages:

```
root@leecher /root# /etc/init.d/rtorrent start
Starting rtorrent.
chmod: cannot access '/var/run/rtorrent/rpc.socket': No such file or directory
chown: cannot access '/var/run/rtorrent/rpc.socket': No such file or directory
rtorrent started successfully.
```

or if execute `rtorrent` manually:

```
root@leecher /var/lib/rtorrent# su - rtorrent -s /bin/bash -c "rtorrent"
rtorrent: Error in option file: ~/.rtorrent.rc:4: Could not prepare socket for listening: No such file or directory
```
